### PR TITLE
增加 proguard 混淆默认规则

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,3 @@
-
 group 'com.jiguang.jverify'
 version '1.0-SNAPSHOT'
 
@@ -29,13 +28,13 @@ android {
         minSdkVersion 17
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
-
+        // library 混淆 -> 随 library 引用，自动添加到 apk 打包混淆
+        consumerProguardFiles 'consumer-rules.pro'
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }
-
-
 }
 
 dependencies {

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,25 @@
+# 极光一键认证
+
+-dontoptimize
+-dontpreverify
+
+-dontwarn cn.jpush.**
+-keep class cn.jpush.** { *; }
+-dontwarn cn.jiguang.**
+-keep class cn.jiguang.** { *; }
+
+-dontwarn cn.com.chinatelecom.**
+-keep class cn.com.chinatelecom.** { *; }
+-dontwarn com.ct.**
+-keep class com.ct.** { *; }
+-dontwarn a.a.**
+-keep class a.a.** { *; }
+-dontwarn com.cmic.**
+-keep class com.cmic.** { *; }
+-dontwarn com.unicom.**
+-keep class com.unicom.** { *; }
+-dontwarn com.sdk.**
+-keep class com.sdk.** { *; }
+
+-dontwarn com.sdk.**
+-keep class com.sdk.** { *; }


### PR DESCRIPTION
配置后集成时无需开发者手动配置混淆。ref: https://docs.jiguang.cn/jverification/client/android_guide/#_9