### PR TITLE
修复JVCustomWidget button 类型设置btnXXXXXXImageName不生效

### DIFF
--- a/android/src/main/java/com/jiguang/jverify/JverifyPlugin.java
+++ b/android/src/main/java/com/jiguang/jverify/JverifyPlugin.java
@@ -1092,6 +1092,7 @@ public class JverifyPlugin implements FlutterPlugin, MethodCallHandler {
         int width = (int) para.get("width");
         int height = (int) para.get("height");
 
+        customView.setPadding(0, 0, 0, 0);
         RelativeLayout.LayoutParams mLayoutParams1 = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.WRAP_CONTENT, RelativeLayout.LayoutParams.WRAP_CONTENT);
         mLayoutParams1.leftMargin = dp2Pix(context, (float) left);
         mLayoutParams1.topMargin = dp2Pix(context, (float) top);
@@ -1100,7 +1101,6 @@ public class JverifyPlugin implements FlutterPlugin, MethodCallHandler {
         }
         if (height > 0) {
             mLayoutParams1.height = dp2Pix(context, (float) height);
-            ;
         }
         customView.setLayoutParams(mLayoutParams1);
 
@@ -1184,11 +1184,9 @@ public class JverifyPlugin implements FlutterPlugin, MethodCallHandler {
         final int normal_resId = getResourceByReflect(normalImageName);
         final int select_resId = getResourceByReflect(pressImageName);
 
-        Bitmap normal_bmp = BitmapFactory.decodeResource(res, normal_resId);
-        Drawable normal_drawable = new BitmapDrawable(res, normal_bmp);
+        Drawable normal_drawable = res.getDrawable(normal_resId);
 
-        Bitmap select_bmp = BitmapFactory.decodeResource(res, select_resId);
-        Drawable select_drawable = new BitmapDrawable(res, select_bmp);
+        Drawable select_drawable = res.getDrawable(select_resId);
 
         // 未选中
         drawable.addState(new int[]{-android.R.attr.state_pressed}, normal_drawable);

--- a/example/ios/Flutter/flutter_export_environment.sh
+++ b/example/ios/Flutter/flutter_export_environment.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # This is a generated file; do not edit or check into version control.
-export "FLUTTER_ROOT=D:\Workspace\android\flutter"
-export "FLUTTER_APPLICATION_PATH=D:\Workspace\work\work\jverify-flutter-plugin\example"
+export "FLUTTER_ROOT=D:\flutter"
+export "FLUTTER_APPLICATION_PATH=D:\Project\jverify-flutter-plugin\example"
+export "COCOAPODS_PARALLEL_CODE_SIGN=true"
 export "FLUTTER_TARGET=lib\main.dart"
 export "FLUTTER_BUILD_DIR=build"
-export "SYMROOT=${SOURCE_ROOT}/../build\ios"
 export "FLUTTER_BUILD_NAME=1.0.0"
 export "FLUTTER_BUILD_NUMBER=1"
 export "DART_OBFUSCATION=false"

--- a/example/ios/Flutter/flutter_export_environment.sh
+++ b/example/ios/Flutter/flutter_export_environment.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # This is a generated file; do not edit or check into version control.
-export "FLUTTER_ROOT=D:\flutter"
-export "FLUTTER_APPLICATION_PATH=D:\Project\jverify-flutter-plugin\example"
-export "COCOAPODS_PARALLEL_CODE_SIGN=true"
+export "FLUTTER_ROOT=D:\Workspace\android\flutter"
+export "FLUTTER_APPLICATION_PATH=D:\Workspace\work\work\jverify-flutter-plugin\example"
 export "FLUTTER_TARGET=lib\main.dart"
 export "FLUTTER_BUILD_DIR=build"
+export "SYMROOT=${SOURCE_ROOT}/../build\ios"
 export "FLUTTER_BUILD_NAME=1.0.0"
 export "FLUTTER_BUILD_NUMBER=1"
 export "DART_OBFUSCATION=false"


### PR DESCRIPTION
fork的2.1.2版本 master分支
在对`setCustomAuthorizationView`方法中添加button类型`JVCustomWidget`时
设置`btnPressedImageName` `btnNormalImageName`在android端不生效的问题
已经测试，可以正常使用。