### PR TITLE
fix: 处理泛型名称和变量名称相同时, flutter web编译到js产生的bug

### DIFF
--- a/lib/jverify.dart
+++ b/lib/jverify.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -991,12 +990,12 @@ enum JVIOSBarStyle {
   StatusBarStyleDarkContent // Dark content, for use on light backgrounds  iOS 13 以上
 }
 
-String getStringFromEnum<T>(T) {
-  if (T == null) {
+String getStringFromEnum<T>(t) {
+  if (t == null) {
     return "";
   }
 
-  return T.toString().split('.').last;
+  return t.toString().split('.').last;
 }
 
 class JVPrivacy {


### PR DESCRIPTION
`jverify.dart`中的`getStringFromEnum`函数由于泛型和参数变量名都为`T`，触发了dart2js的一个bug，导致在web端无法启动。
这个提交中把参数名称改为`t`，与泛型`T`区分开来。
<img width="976" alt="Screenshot 2024-01-19 at 13 43 28" src="https://github.com/jpush/jverify-flutter-plugin/assets/10418364/8addb44b-81f9-4f89-86ef-8934479ae989">
